### PR TITLE
Attempt to fix some corner-case scenarios, while preserving compatibility

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,26 +19,29 @@ If you have any problem or find some errors in the notebooks/homeworks please co
 
 Download, clone or fork (your choice) this repository in a directory `PATH_TO_DIR/`.
 
-Create a virtual environment using `python3`
+Create a virtual environment using `python3` (commands are provided for *Debian-like* GNU/Linux distributions)
 ```
 cd PATH_TO_DIR/statistical-machine-learning/
 sudo apt-get install python3-pip
-pip3 install virtualenv
-virtualenv -p /usr/bin/python3 venv
+python3 -m pip install virtualenv
+python3 -m virtualenv -p "$(which python3)" venv
 ```
 
 Now you should see `PATH_TO_DIR/statistical-machine-learning/venv/` folder.
 Activate the enviroment and install the requirements:
 ```
 source venv/bin/activate
-pip3 install -r requirements.txt 
+python3 -m pip install -r ./requirements.txt 
+```
+
+Register the just-installed virtual environment for use with Jupyter:
+```
+python3 -m ipykernel install --user --name statistical-machine-learning --display-name "Python (SML virtualenv)"
 ```
 
 Open your notebooks using jupyter-notebook (or jupyter-lab):
 ```
-python3 -m notebook
+python3 -m jupyter notebook
 ```
 
-To deactivate the environment use `deactivate` command.
-
-
+To deactivate the environment use `source deactivate` command.

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Create a virtual environment using `python3` (commands are provided for *Debian-
 ```
 cd PATH_TO_DIR/statistical-machine-learning/
 sudo apt-get install python3-pip
-python3 -m pip install virtualenv
+python3 -m pip install --user virtualenv
 python3 -m virtualenv -p "$(which python3)" venv
 ```
 


### PR DESCRIPTION
Following some *internal* bug reports, some *in-house* testing, and a little of spare time, some corner-cases were discovered leading to a non-functioning virtual environment or a working Python REPL without a working `jupyter` environment.

They mostly relate to *non-standard* (but common) scenarios, namely: always-on `conda` environments, pre-3.7 Python versions with specific `pip` versioning, systemwide `pip` configuration overriding in-`virtualenv` `pip` commands with the `--user` flag.

This PR attempts to fix the installation procedure in such scenarios, providing a unified experience without excessive burden for the general user, or compatibility breakage.